### PR TITLE
Suppress error messages for command line window

### DIFF
--- a/autoload/tabman.vim
+++ b/autoload/tabman.vim
@@ -208,9 +208,9 @@ fu! s:ManUpdate(type)
 		let winnr = s:bufwinnr()
 		if winnr > 0
 			let currwin = winnr()
-			exe winnr.'winc w'
+			silent! exe winnr.'winc w'
 			cal s:ManUpdate(1)
-			exe currwin.'winc w'
+			silent! exe currwin.'winc w'
 		en
 	en
 endf


### PR DESCRIPTION
If command line window is opened with tabman window,
it raises error messages for update tabman infomations.

Added `silent!` to avoid it.

#### How to Repro

1. Set `let g:tabman_specials = 1` in `.vimrc`
2. Run vim
3. Open tabman window (`<leader>mf`)
4. Open command line window (`q:` or `:` -> `<C-f>`)
5. It raises errors in `s:ManUpdate()`

If `g:tabman_specials` is not set, it doesn't occur.
Probably because command line window is not checked.
