### PR TITLE
Add keybind for terminal window

### DIFF
--- a/plugin/tabman.vim
+++ b/plugin/tabman.vim
@@ -14,5 +14,9 @@ if !exists('g:tabman_toggle') | let g:tabman_toggle = '<leader>mt' | en
 com! TMFocus  cal tabman#focus()
 com! TMToggle cal tabman#toggle()
 
-exe 'nn <silent>' g:tabman_focus  ':<c-u>TMFocus<cr>'
-exe 'nn <silent>' g:tabman_toggle ':<c-u>TMToggle<cr>'
+exe 'nn  <silent>'           g:tabman_focus            ':<c-u>TMFocus'  . '<cr>'
+exe 'nn  <silent>' '<c-w>' . g:tabman_focus            ':<c-u>TMFocus'  . '<cr>'
+exe 'tno <silent>'           g:tabman_focus  '<c-w>' . ':<c-u>TMFocus'  . '<cr>'
+exe 'nn  <silent>'           g:tabman_toggle           ':<c-u>TMToggle' . '<cr>'
+exe 'nn  <silent>' '<c-w>' . g:tabman_toggle           ':<c-u>TMToggle' . '<cr>'
+exe 'tno <silent>'           g:tabman_toggle '<c-w>' . ':<c-u>TMToggle' . '<cr>'


### PR DESCRIPTION
Current keybind setting does not work in terminal windows unless `<c-w> <c-n>` (terminal window suspend).
So added `tno` binds.

And, user may push unneeded `<c-w>` key for normal mode (as terminal windows does need),
also added them too.