### PR TITLE
Add List Name `buftype` Handling (and Bugfix for `quickfix`)

### DIFF
--- a/autoload/tabman.vim
+++ b/autoload/tabman.vim
@@ -312,8 +312,10 @@ endf
 fu! s:validbufs(bufs)
 	let bufs = {}
 	for each in a:bufs
-		let bufname = empty(bufname(each)) ? '<no name>'
-			\ : getbufvar(each, '&bt') == 'quickfix' ? 'quickfix' : bufname(each)
+		let bufname = bufname(each)
+		if empty(bufname)
+			let bufname = getbufvar(each, '&bt') == 'quickfix' ? 'quickfix' : '<no name>'
+		en
 		if (getbufvar(each, '&bl') && !empty(bufname(each))
 			\ && empty(getbufvar(each, '&bt')) && getbufvar(each, '&ma')) || s:special
 			let mod = getbufvar(each, '&mod') ? '+' : ''

--- a/autoload/tabman.vim
+++ b/autoload/tabman.vim
@@ -312,14 +312,19 @@ endf
 fu! s:validbufs(bufs)
 	let bufs = {}
 	for each in a:bufs
-		let bufname = bufname(each)
+		let bufname = [fnamemodify(bufname(each), ':t')]
+		let buftype = getbufvar(each, '&bt')
+		if buftype == 'quickfix' || buftype == 'help' || buftype == 'terminal'
+			let bufname = ['<' . buftype . '>'] + bufname
+		en
+		let bufname = join(bufname)
 		if empty(bufname)
-			let bufname = getbufvar(each, '&bt') == 'quickfix' ? 'quickfix' : '<no name>'
+			let bufname = '<no name>'
 		en
 		if (getbufvar(each, '&bl') && !empty(bufname(each))
 			\ && empty(getbufvar(each, '&bt')) && getbufvar(each, '&ma')) || s:special
 			let mod = getbufvar(each, '&mod') ? '+' : ''
-			cal extend(bufs, { each : [fnamemodify(bufname, ':t').mod] })
+			cal extend(bufs, { each : [bufname . mod] })
 		en
 	endfo
 	retu bufs


### PR DESCRIPTION
Add indicator for `buftype` of `help` and `terminal`.

Also, it had tried to list as `quickfix` for quickfix or location list windows,
though, it had not worked only to set as `<no name>`.