### PR TITLE
Error in Window Closing

### DIFF
--- a/autoload/tabman.vim
+++ b/autoload/tabman.vim
@@ -161,8 +161,13 @@ fu! s:ManDelete(...)
 		if exists('a:1')
 			exe 'bd' matchstr(eval, '\d\+\ze\w\d\+$')
 		el
-			let [currtab, currwin, s:snew] = [tabpagenr(), winnr(), 1]
+			let [currtab, currwin, lasttab, s:snew] = [tabpagenr(), winnr(), tabpagenr('$'), 1]
 			cal s:ManSelect()
+			if tabpagenr() < currtab && tabpagenr('$') < lasttab
+				let currtab -= 1
+			elseif tabpagenr() == currtab && winnr() <= currwin
+				let currwin -= 1
+			en
 			clo
 			exe 'tabn' currtab '|' currwin.'winc w'
 			unl s:snew


### PR DESCRIPTION
It shows an error in window closing by `x` key in TabManager window:

```text
function <SNR>156_ManDelete の処理中にエラーが検出されました:
行   22:
E16: 無効な範囲です:  3winc w
```

It says unavialable range of `3`.

Do below to repro:

1.  Set `let g:tabman_side = 'right'` in `.vimrc`
2. Run vim
    - 1 window exists
3. Open new window
    - 2 window exists
4. Open TabManager window
    - 3 window exists
5. Close a window by `x` hotkey in TabManager window
    - Then, it closes a window, and it has 2 windows including TabManager
    - After that, it tries to close window `3`, but range over
        - It was old TabManager window number in `g:tabman_side = 'right'` case

I think this line is unnecessary.
Why you do this line?
