### PR TITLE
Fix going back window no. on tabman close

### DIFF
--- a/autoload/tabman.vim
+++ b/autoload/tabman.vim
@@ -107,7 +107,7 @@ fu! s:Close()
 		if winnr == winnr()
 			let currwin = s:side == 'left' ? winnr('#') - 1 : winnr('#')
 		el
-			let currwin = s:side == 'left' ? winnr() - 1 : winnr()
+			let currwin = winnr() > winnr ? winnr() - 1 : winnr()
 			exe winnr.'winc w'
 		en
 		try | clo! | cat | cal s:msg("Can't close last window.") | endt


### PR DESCRIPTION
In going back to the current active window on tabman close,
there is some case to move back to wrong window no.

### Repro

```vim
" .vimrc

let g:tabman_side     = 'right'
```

```vim
" Open tabman (in right side) : tabman winnr = 2
" +---+-----------+
" |   |           |
" | 1 | 2: tabman |
" |   |           |
" +---+-----------+
\mt

" Open new window : winnr = 3
" +---+-----------+
" |   | 2: tabman |
" | 1 +-----------+
" |   |     3     |
" +---+-----------+
:below new

" Close tabman (winnr = 2),
" and try to go back to the window 3, but fails:
" the window number has been changed.
" +---+-----------+
" |   |           |
" | 1 |  3 -> 2   |
" |   |           |
" +---+-----------+
\mt
```
